### PR TITLE
feat: UTXO splitting for large TXs & Payment Cancel API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /data
 .idea/
+.vscode/
 
 .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,8 +1938,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "bs58 0.5.1",
  "serde",
@@ -1947,8 +1947,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1981,6 +1981,7 @@ dependencies = [
  "tari_common",
  "tari_common_types",
  "tari_crypto",
+ "tari_script",
  "tari_transaction_components",
  "tari_utilities",
  "tempfile",
@@ -3780,8 +3781,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3803,8 +3804,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "argon2",
  "base64 0.21.7",
@@ -3862,13 +3863,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 
 [[package]]
 name = "tari_hashing"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "blake2",
  "borsh",
@@ -3878,8 +3879,8 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "borsh",
  "digest",
@@ -3892,8 +3893,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "borsh",
  "serde",
@@ -3903,8 +3904,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "blake2",
  "borsh",
@@ -3921,16 +3922,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "futures",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "borsh",
  "hex",
@@ -3946,8 +3947,8 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.2.0-pre.5"
-source = "git+https://github.com/tari-project/tari/?rev=ed473c3c94c2219ac1eebb9345384b6a7245606c#ed473c3c94c2219ac1eebb9345384b6a7245606c"
+version = "5.2.0-pre.6"
+source = "git+https://github.com/tari-project/tari/?rev=9406e482007ac8b8c63db8b76fd8fd92d244ca09#9406e482007ac8b8c63db8b76fd8fd92d244ca09"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Because the application uses structured configuration, hierarchical settings (li
     *   Example: `LISTEN_PORT="9145"`
 *   **`CONFIRMATION_CHECKER_REQUIRED_CONFIRMATIONS`** (Optional): The number of confirmations required before a transaction is considered final. Defaults to `10`.
     *   Example: `CONFIRMATION_CHECKER_REQUIRED_CONFIRMATIONS="10"`
+*   **`MAX_INPUT_COUNT_PER_TX`** (Optional): The max number of UTXOs, which can be used in a single transaction. If it exceeds this amount, we do a COINJOIN. Defaults to `400`.
+    *   Example: `MAX_INPUT_COUNT_PER_TX="200"`
 
 ### Account Configuration
 

--- a/docs/architecture/state-descriptions.md
+++ b/docs/architecture/state-descriptions.md
@@ -2,11 +2,11 @@
 
 | Status | Worker Responsible | Description |
 | :--- | :--- | :--- |
-| **PENDING_BATCHING** | `Batch Creator` | A new batch has been created from individual payments. It waits for the transaction structure to be built. |
-| **AWAITING_SIGNATURE** | `Unsigned TX Creator` | The transaction structure (unsigned) has been retrieved from the Wallet API. It is ready to be signed. |
-| **SIGNING_IN_PROGRESS** | `Transaction Signer` | A worker has picked up the batch and is currently calculating the signature (CPU intensive). |
-| **AWAITING_BROADCAST** | `Transaction Signer` | The transaction is fully signed and stored in the DB, ready to be sent to the network. |
-| **BROADCASTING** | `Broadcaster` | A worker is currently attempting to submit the transaction to the Base Node. |
-| **AWAITING_CONFIRMATION** | `Broadcaster` | The transaction was accepted by the mempool. The system is now polling for block depth. |
-| **CONFIRMED** | `Confirmation Checker` | The transaction has reached the required block depth (e.g., 10 blocks). |
-| **FAILED** | All | A terminal state indicating a non-recoverable error (or max retries reached). |
+| **PENDING_BATCHING** | `Batch Creator` / `Broadcaster` | A new batch created, OR a batch that has completed a consolidation cycle (Split) and is waiting for the final transaction to be built using the new UTXOs. |
+| **AWAITING_SIGNATURE** | `Unsigned TX Creator` | The transaction structure (unsigned) has been retrieved. It may be a CoinJoin (Split) or a Final Payment. |
+| **SIGNING_IN_PROGRESS** | `Transaction Signer` | A worker has picked up the batch and is calculating signatures. |
+| **AWAITING_BROADCAST** | `Transaction Signer` | The transaction is fully signed and stored in the DB. |
+| **BROADCASTING** | `Broadcaster` | Submitting transactions. If `is_consolidation=true`, it verifies mempool presence and loops status back to `PENDING_BATCHING`. If `false`, moves to `AWAITING_CONFIRMATION`. |
+| **AWAITING_CONFIRMATION** | `Broadcaster` | The final transaction was accepted. System polls for block depth. |
+| **CONFIRMED** | `Confirmation Checker` | The transaction has reached the required block depth. |
+| **FAILED** | All | Terminal error state. |

--- a/docs/db/db_schema.sql
+++ b/docs/db/db_schema.sql
@@ -83,6 +83,6 @@ CREATE TABLE payment_batches (
     -- Timestamps
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
+, intermediate_context_json TEXT);
 CREATE INDEX idx_payments_status ON payments(status);
 CREATE INDEX idx_payment_batches_status ON payment_batches(status);

--- a/migrations/20251201115213_add_intermediate_context.sql
+++ b/migrations/20251201115213_add_intermediate_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment_batches ADD COLUMN intermediate_context_json TEXT;

--- a/minotari_payment_processor/Cargo.toml
+++ b/minotari_payment_processor/Cargo.toml
@@ -25,11 +25,12 @@ minotari-client = { path = "../minotari-client" }
 uuid = { version = "1", features = ["v4"] }
 tempfile = "3.23.0"
 
-minotari_node_wallet_client  = { git = "https://github.com/tari-project/tari/", rev = "ed473c3c94c2219ac1eebb9345384b6a7245606c" }
-tari_common = { git = "https://github.com/tari-project/tari/", rev = "ed473c3c94c2219ac1eebb9345384b6a7245606c" }
-tari_common_types = { git = "https://github.com/tari-project/tari/", rev = "ed473c3c94c2219ac1eebb9345384b6a7245606c" }
+minotari_node_wallet_client  = { git = "https://github.com/tari-project/tari/", rev = "9406e482007ac8b8c63db8b76fd8fd92d244ca09" }
+tari_common = { git = "https://github.com/tari-project/tari/", rev = "9406e482007ac8b8c63db8b76fd8fd92d244ca09" }
+tari_common_types = { git = "https://github.com/tari-project/tari/", rev = "9406e482007ac8b8c63db8b76fd8fd92d244ca09" }
+tari_script  = { git = "https://github.com/tari-project/tari/", rev = "9406e482007ac8b8c63db8b76fd8fd92d244ca09" }
 tari_crypto = { version = "0.22.1", features = ["borsh"] }
-tari_transaction_components  = { git = "https://github.com/tari-project/tari/", rev = "ed473c3c94c2219ac1eebb9345384b6a7245606c" }
+tari_transaction_components  = { git = "https://github.com/tari-project/tari/", rev = "9406e482007ac8b8c63db8b76fd8fd92d244ca09" }
 tari_utilities = { version = "0.8" }
 hex = "0.4.3"
 dotenv = "0.15.0"

--- a/minotari_payment_processor/src/api/mod.rs
+++ b/minotari_payment_processor/src/api/mod.rs
@@ -31,12 +31,16 @@ impl FromRef<AppState> for SqlitePool {
         version::api_get_version,
         payments::api_create_payment,
         payments::api_get_payment,
+        payments::api_cancel_payment,
     ),
     components(
         schemas(
             version::ServiceVersion,
             payments::PaymentRequest,
             payments::PaymentResponse,
+            payments::PaymentCancelResponse,
+            crate::db::payment::PaymentStatus,
+            error::ApiError,
         )
     ),
     tags(
@@ -53,5 +57,6 @@ pub fn create_router(db_pool: SqlitePool, env: PaymentProcessorEnv) -> Router {
         .route("/health/version", get(version::api_get_version))
         .route("/v1/payments", post(payments::api_create_payment))
         .route("/v1/payments/{payment_id}", get(payments::api_get_payment))
+        .route("/v1/payments/{payment_id}/cancel", post(payments::api_cancel_payment))
         .with_state(app_state)
 }

--- a/minotari_payment_processor/src/config.rs
+++ b/minotari_payment_processor/src/config.rs
@@ -39,6 +39,7 @@ pub struct PaymentProcessorEnv {
     pub broadcaster_sleep_secs: Option<u64>,
     pub confirmation_checker_sleep_secs: Option<u64>,
     pub confirmation_checker_required_confirmations: Option<u64>,
+    pub max_input_count_per_tx: usize,
     pub accounts: HashMap<String, PaymentReceiverAccount>,
 }
 
@@ -69,6 +70,7 @@ struct RawSettings {
     broadcaster_sleep_secs: Option<u64>,
     confirmation_checker_sleep_secs: Option<u64>,
     confirmation_checker_required_confirmations: Option<u64>,
+    max_input_count_per_tx: Option<usize>,
     #[serde(default)]
     accounts: HashMap<String, RawAccount>,
 }
@@ -150,6 +152,7 @@ impl TryFrom<RawSettings> for PaymentProcessorEnv {
             broadcaster_sleep_secs: raw.broadcaster_sleep_secs,
             confirmation_checker_sleep_secs: raw.confirmation_checker_sleep_secs,
             confirmation_checker_required_confirmations: raw.confirmation_checker_required_confirmations,
+            max_input_count_per_tx: raw.max_input_count_per_tx.unwrap_or(400).min(400),
             accounts,
         })
     }

--- a/minotari_payment_processor/src/main.rs
+++ b/minotari_payment_processor/src/main.rs
@@ -35,6 +35,7 @@ async fn main() -> anyhow::Result<()> {
         client_config.clone(),
         env.tari_network,
         env.accounts.clone(),
+        env.max_input_count_per_tx,
         env.unsigned_tx_creator_sleep_secs,
     ));
     tokio::spawn(workers::transaction_signer::run(

--- a/minotari_payment_processor/src/workers/broadcaster.rs
+++ b/minotari_payment_processor/src/workers/broadcaster.rs
@@ -1,13 +1,19 @@
 use anyhow::{Context, anyhow};
 use minotari_node_wallet_client::{BaseNodeWalletClient, http::Client};
 use sqlx::{SqliteConnection, SqlitePool};
-use tari_transaction_components::offline_signing::models::SignedOneSidedTransactionResult;
+use tari_transaction_components::rpc::models::TxLocation;
+use tari_transaction_components::{
+    offline_signing::models::SignedOneSidedTransactionResult, transaction_components::Transaction,
+};
+use tari_utilities::ByteArray;
 use tari_utilities::message_format::MessageFormat;
 use tokio::time::{self, Duration};
 
-use crate::db::payment_batch::{PaymentBatch, PaymentBatchStatus};
+use crate::db::payment_batch::{BatchPayload, PaymentBatch, PaymentBatchStatus, StepPayload};
 
 const DEFAULT_SLEEP_SECS: u64 = 15;
+const MEMPOOL_CHECK_RETRIES: usize = 10;
+const MEMPOOL_CHECK_DELAY: Duration = Duration::from_secs(2);
 
 pub async fn run(db_pool: SqlitePool, base_node_client: Client, sleep_secs: Option<u64>) {
     let sleep_secs = sleep_secs.unwrap_or(DEFAULT_SLEEP_SECS);
@@ -42,15 +48,15 @@ async fn process_transactions_to_broadcast(
         if let Err(e) = process_single_batch(&mut conn, base_node_client, &batch).await {
             let error_message = e.to_string();
             eprintln!(
-                "Error broadcasting batch {}: {}. Incrementing retry count.",
+                "Error broadcasting batch {}: {}. Attempting to revert status...",
                 batch.id, error_message
             );
 
-            if let Err(db_err) = PaymentBatch::increment_retry_count(&mut conn, &batch.id, &error_message).await {
-                eprintln!(
-                    "CRITICAL: Failed to update retry count for batch {}: {:?}",
-                    batch.id, db_err
-                );
+            match PaymentBatch::update_to_awaiting_broadcast_for_retry(&mut conn, &batch.id).await {
+                Ok(_) => println!("INFO: Batch {} reverted to 'AwaitingBroadcast'.", batch.id),
+                Err(revert_e) => {
+                    eprintln!("CRITICAL: Failed to revert batch {} status: {:?}", batch.id, revert_e)
+                },
             }
         }
     }
@@ -66,45 +72,145 @@ async fn process_single_batch(
     let batch_id = &batch.id;
     println!("INFO: Starting broadcast sequence for Batch ID: {}", batch_id);
 
-    let signed_tx_json = batch
-        .signed_tx_json
-        .clone()
-        .ok_or_else(|| anyhow!("Batch {} has no signed_tx_json", batch_id))?;
-
-    let signed_tx = SignedOneSidedTransactionResult::from_json(&signed_tx_json)
-        .map_err(|e| anyhow!("Failed to deserialize signed tx: {}", e))?;
-
     PaymentBatch::update_to_broadcasting(conn, batch_id)
         .await
         .context("Failed to set status to broadcasting")?;
 
+    let signed_json_str = batch
+        .signed_tx_json
+        .clone()
+        .ok_or_else(|| anyhow!("Batch {} has no signed_tx_json", batch_id))?;
+
+    let payload = BatchPayload::from_json(&signed_json_str)?;
+    let is_consolidation_cycle = payload.steps.first().map(|s| s.is_consolidation).unwrap_or(false);
+
     println!(
-        "INFO: Batch {}: Status updated to 'Broadcasting'. Submitting to Base Node...",
-        batch_id
+        "INFO: Batch {}: Broadcasting {} transactions... (Consolidation: {})",
+        batch_id,
+        payload.steps.len(),
+        is_consolidation_cycle
     );
 
-    let response = base_node_client
-        .submit_transaction(signed_tx.signed_transaction.transaction)
-        .await
-        .context("Network error submitting transaction to Base Node")?;
+    let mut step_tx_objects = Vec::new();
 
-    if response.accepted {
-        println!("INFO: Batch {}: Transaction ACCEPTED by Base Node.", batch_id);
+    for (i, step) in payload.steps.iter().enumerate() {
+        let signed_json = match &step.payload {
+            StepPayload::Signed(s) => s,
+            StepPayload::Unsigned(_) => return Err(anyhow!("Step {} is not signed!", i)),
+        };
+        let signed_tx_wrapper = SignedOneSidedTransactionResult::from_json(signed_json)
+            .map_err(|e| anyhow!("Failed to deserialize signed tx for step {}: {}", i, e))?;
+
+        let tx = signed_tx_wrapper.signed_transaction.transaction.clone();
+        step_tx_objects.push(tx.clone());
+
+        println!(
+            "INFO: Batch {}: Submitting TX for Step {}/{} (Internal ID: {})",
+            batch_id,
+            i + 1,
+            payload.steps.len(),
+            step.tx_id
+        );
+
+        let response = base_node_client
+            .submit_transaction(tx)
+            .await
+            .context("Network error submitting transaction to Base Node")?;
+
+        if response.accepted {
+            println!("INFO: Batch {}: Step {} ACCEPTED by Base Node.", batch_id, i + 1);
+        } else {
+            println!(
+                "WARN: Batch {}: Step {} REJECTED by Base Node. Reason: {}",
+                batch_id,
+                i + 1,
+                response.rejection_reason
+            );
+            return Err(anyhow!(
+                "Tari base node rejected transaction in step {}: {}",
+                i + 1,
+                response.rejection_reason
+            ));
+        }
+    }
+
+    if is_consolidation_cycle {
+        // === SPLIT CYCLE DETECTED ===
+        println!(
+            "INFO: Batch {}: Split Cycle detected. Verifying Mempool propagation...",
+            batch_id
+        );
+
+        verify_txs_in_mempool(base_node_client, &step_tx_objects).await?;
+
+        println!("INFO: Batch {}: All split transactions found in Mempool.", batch_id);
+        println!(
+            "INFO: Batch {}: LOOPING BACK state to 'PendingBatching' for Cycle 2.",
+            batch_id
+        );
+
+        PaymentBatch::reset_to_pending_batching(conn, batch_id)
+            .await
+            .context("Failed to reset batch to PendingBatching")?;
+    } else {
+        // === NORMAL / FINAL CYCLE ===
+        println!(
+            "INFO: Batch {}: Final transaction submitted. Updating to 'AwaitingConfirmation'.",
+            batch_id
+        );
 
         PaymentBatch::update_to_awaiting_confirmation(conn, batch_id)
             .await
             .context("Failed to update status to AwaitingConfirmation")?;
+    }
 
-        println!("INFO: Batch {}: Status updated to 'AwaitingConfirmation'.", batch_id);
-    } else {
-        println!(
-            "WARN: Batch {}: Transaction REJECTED by Base Node. Reason: {}",
-            batch_id, response.rejection_reason
-        );
-        return Err(anyhow!(
-            "Tari base node rejected transaction: {}",
-            response.rejection_reason
-        ));
+    Ok(())
+}
+
+/// Polls the base node to ensure the submitted transactions are visible in the mempool.
+async fn verify_txs_in_mempool(base_node_client: &Client, txs: &[Transaction]) -> Result<(), anyhow::Error> {
+    for (i, tx) in txs.iter().enumerate() {
+        let kernel = tx
+            .body
+            .kernels()
+            .first()
+            .ok_or_else(|| anyhow!("Transaction {} has no kernels", i))?;
+
+        let excess_public = kernel.excess_sig.get_compressed_public_nonce().to_vec();
+        let excess_sig = kernel.excess_sig.get_signature().to_vec();
+
+        let mut retries = 0;
+        let mut found = false;
+
+        while retries < MEMPOOL_CHECK_RETRIES {
+            let response = base_node_client
+                .transaction_query(excess_public.clone(), excess_sig.clone())
+                .await
+                .context("Failed to query transaction status")?;
+
+            match response.location {
+                TxLocation::InMempool => {
+                    found = true;
+                    break;
+                },
+                TxLocation::Mined => {
+                    found = true;
+                    break;
+                },
+                TxLocation::NotStored | TxLocation::None => {
+                    time::sleep(MEMPOOL_CHECK_DELAY).await;
+                    retries += 1;
+                },
+            }
+        }
+
+        if !found {
+            return Err(anyhow!(
+                "Transaction {} (Step {}) did not appear in mempool after retries. Aborting loop-back.",
+                i,
+                i + 1
+            ));
+        }
     }
 
     Ok(())

--- a/minotari_payment_processor/src/workers/mod.rs
+++ b/minotari_payment_processor/src/workers/mod.rs
@@ -2,4 +2,5 @@ pub mod batch_creator;
 pub mod broadcaster;
 pub mod confirmation_checker;
 pub mod transaction_signer;
+pub mod types;
 pub mod unsigned_tx_creator;

--- a/minotari_payment_processor/src/workers/transaction_signer.rs
+++ b/minotari_payment_processor/src/workers/transaction_signer.rs
@@ -2,12 +2,18 @@ use anyhow::{Context, anyhow};
 use sqlx::{SqliteConnection, SqlitePool};
 use std::io::Write;
 use tari_common::configuration::Network;
+use tari_transaction_components::key_manager::SerializedKeyString;
+use tari_transaction_components::key_manager::TariKeyId;
+use tari_transaction_components::offline_signing::models::SignedOneSidedTransactionResult;
+use tari_transaction_components::offline_signing::models::TransactionResult;
 use tempfile::NamedTempFile;
 use tokio::fs;
 use tokio::process::Command;
 use tokio::time::{self, Duration};
 
-use crate::db::payment_batch::{PaymentBatch, PaymentBatchStatus};
+use crate::db::payment_batch::StepPayload;
+use crate::db::payment_batch::{BatchPayload, PaymentBatch, PaymentBatchStatus};
+use crate::workers::types::IntermediateContext;
 
 const DEFAULT_SLEEP_SECS: u64 = 10;
 
@@ -115,47 +121,88 @@ async fn process_single_batch(
 
     println!("INFO: Batch {}: Status updated to 'SigningInProgress'.", batch_id);
 
-    let unsigned_tx_json = batch
+    let unsigned_json_str = batch
         .unsigned_tx_json
         .clone()
         .ok_or_else(|| anyhow!("Batch {} has no unsigned_tx_json", batch_id))?;
 
-    let mut input_file = NamedTempFile::with_prefix("unsigned-tx-").context("Failed to create temp input file")?;
-    let input_path = input_file.path().to_path_buf();
+    let mut payload = BatchPayload::from_json(&unsigned_json_str)?;
+    let steps_count = payload.steps.len();
 
-    input_file
-        .write_all(unsigned_tx_json.as_bytes())
-        .context("Failed to write unsigned tx to temp file")?;
-    input_file.flush().context("Failed to flush input file")?;
+    println!("INFO: Batch {}: Found {} steps to sign.", batch_id, payload.steps.len());
 
-    let output_file = NamedTempFile::with_prefix("signed-tx-").context("Failed to create temp output file")?;
-    let output_path = output_file.path().to_path_buf();
+    let mut consolidated_wallet_outputs = vec![];
+    for (i, step) in payload.steps.iter_mut().enumerate() {
+        println!(
+            "INFO: Batch {}: Signing Step {}/{} (ID: {})",
+            batch_id,
+            i + 1,
+            steps_count,
+            step.tx_id
+        );
 
-    println!(
-        "INFO: Batch {}: Temp files prepared. Input: {:?}, Output: {:?}",
-        batch_id, input_path, output_path
-    );
+        let unsigned_json = match &step.payload {
+            StepPayload::Unsigned(s) => s,
+            StepPayload::Signed(_) => return Err(anyhow!("Step {} is already signed!", i)),
+        };
 
-    println!("INFO: Batch {}: Invoking external signer CLI...", batch_id);
+        let mut input_file = NamedTempFile::with_prefix(format!("unsigned-tx-{}-step{}-", batch_id, i))
+            .context("Failed to create temp input file")?;
+        let input_path = input_file.path().to_path_buf();
 
-    sign_with_cli(
-        network,
-        console_wallet_path,
-        console_wallet_password,
-        console_wallet_base_path,
-        &input_path,
-        &output_path,
-    )
-    .await
-    .context("External signing process failed")?;
+        input_file
+            .write_all(unsigned_json.as_bytes())
+            .context("Failed to write unsigned tx to temp file")?;
+        input_file.flush().context("Failed to flush input file")?;
 
-    println!("INFO: Batch {}: External signer CLI finished successfully.", batch_id);
+        let output_file = NamedTempFile::with_prefix(format!("signed-tx-{}-step{}-", batch_id, i))
+            .context("Failed to create temp output file")?;
+        let output_path = output_file.path().to_path_buf();
 
-    let signed_tx_json = fs::read_to_string(&output_path)
+        sign_with_cli(
+            network,
+            console_wallet_path,
+            console_wallet_password,
+            console_wallet_base_path,
+            &input_path,
+            &output_path,
+        )
         .await
-        .context("Failed to read signed transaction from output file")?;
+        .context(format!("External signing process failed for step {}", i))?;
 
-    PaymentBatch::update_to_awaiting_broadcast(conn, batch_id, &signed_tx_json)
+        let signed_json = fs::read_to_string(&output_path)
+            .await
+            .context("Failed to read signed transaction from output file")?;
+
+        if step.is_consolidation {
+            let signed_tx_wrapper = SignedOneSidedTransactionResult::from_json(&signed_json)
+                .map_err(|e| anyhow!("Failed to deserialize signed tx for step {}: {}", i, e))?;
+            for output in &signed_tx_wrapper.signed_transaction.outputs {
+                let mut cloned_output = output.clone();
+                let script_key_id = TariKeyId::Derived {
+                    key: SerializedKeyString::from(output.commitment_mask_key_id().to_string()),
+                };
+                cloned_output.set_script_key_id(script_key_id);
+                consolidated_wallet_outputs.push(cloned_output);
+            }
+        }
+
+        step.payload = StepPayload::Signed(signed_json);
+    }
+
+    println!("INFO: Batch {}: All steps signed successfully.", batch_id);
+
+    let intermediate_context = if consolidated_wallet_outputs.is_empty() {
+        None
+    } else {
+        let ctx = IntermediateContext {
+            utxos: consolidated_wallet_outputs,
+        };
+        Some(ctx.to_json()?)
+    };
+
+    let signed_payload_json = payload.to_json()?;
+    PaymentBatch::update_to_awaiting_broadcast(conn, batch_id, &signed_payload_json, intermediate_context.as_deref())
         .await
         .context("Failed to update status to AwaitingBroadcast")?;
 

--- a/minotari_payment_processor/src/workers/types.rs
+++ b/minotari_payment_processor/src/workers/types.rs
@@ -1,0 +1,18 @@
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use tari_transaction_components::transaction_components::WalletOutput;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IntermediateContext {
+    pub utxos: Vec<WalletOutput>,
+}
+
+impl IntermediateContext {
+    pub fn from_json(json: &str) -> anyhow::Result<Self> {
+        serde_json::from_str(json).context("Failed to deserialize intermediate context")
+    }
+
+    pub fn to_json(&self) -> anyhow::Result<String> {
+        serde_json::to_string(self).context("Failed to serialize intermediate context")
+    }
+}

--- a/minotari_payment_processor/src/workers/unsigned_tx_creator.rs
+++ b/minotari_payment_processor/src/workers/unsigned_tx_creator.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tari_common::configuration::Network;
 use tari_common_types::tari_address::TariAddress;
 use tari_common_types::transaction::TxId;
+use tari_script::TariScript;
 use tari_transaction_components::consensus::ConsensusConstantsBuilder;
 use tari_transaction_components::key_manager::{
     KeyManager,
@@ -15,22 +16,30 @@ use tari_transaction_components::key_manager::{
 use tari_transaction_components::offline_signing::{PaymentRecipient, prepare_one_sided_transaction_for_signing};
 use tari_transaction_components::{
     TransactionBuilder,
+    fee::Fee,
+    helpers::borsh::SerializedSize,
     tari_amount::MicroMinotari,
-    transaction_components::{MemoField, OutputFeatures, WalletOutput, memo_field::TxType},
+    transaction_components::{MemoField, OutputFeatures, WalletOutput, covenants::Covenant, memo_field::TxType},
+    weight::TransactionWeight,
 };
 use tokio::time::{self, Duration};
 
 use crate::config::PaymentReceiverAccount;
 use crate::db::payment::Payment;
-use crate::db::payment_batch::{PaymentBatch, PaymentBatchStatus};
+use crate::db::payment_batch::{BatchPayload, PaymentBatch, PaymentBatchStatus, StepPayload, TransactionStep};
+use crate::workers::types::IntermediateContext;
 
 const DEFAULT_SLEEP_SECS: u64 = 15;
+const FEE_PER_GRAM: u64 = 5;
+// Buffer to ensure we have enough funds left for the final payment after paying for split fees.
+const FEE_BUFFER_AMOUNT: i64 = 200_000;
 
 pub async fn run(
     db_pool: SqlitePool,
     client_config: Arc<Configuration>,
     network: Network,
     accounts: HashMap<String, PaymentReceiverAccount>,
+    max_input_count_per_tx: usize,
     sleep_secs: Option<u64>,
 ) {
     let sleep_secs = sleep_secs.unwrap_or(DEFAULT_SLEEP_SECS);
@@ -43,7 +52,9 @@ pub async fn run(
 
     loop {
         interval.tick().await;
-        if let Err(e) = process_unsigned_transactions(&db_pool, &client_config, network, &accounts).await {
+        if let Err(e) =
+            process_unsigned_transactions(&db_pool, &client_config, network, &accounts, max_input_count_per_tx).await
+        {
             eprintln!("Unsigned Transaction Creator worker error: {:?}", e);
         }
     }
@@ -54,6 +65,7 @@ async fn process_unsigned_transactions(
     client_config: &Configuration,
     network: Network,
     accounts: &HashMap<String, PaymentReceiverAccount>,
+    max_input_count_per_tx: usize,
 ) -> Result<(), anyhow::Error> {
     let mut conn = db_pool.acquire().await?;
 
@@ -67,7 +79,16 @@ async fn process_unsigned_transactions(
     }
 
     for batch in batches {
-        if let Err(e) = process_single_batch(&mut conn, client_config, network, accounts, &batch).await {
+        if let Err(e) = process_single_batch(
+            &mut conn,
+            client_config,
+            network,
+            accounts,
+            &batch,
+            max_input_count_per_tx,
+        )
+        .await
+        {
             let error_message = e.to_string();
             eprintln!(
                 "Error processing batch {}: {}. Incrementing retry count.",
@@ -92,6 +113,7 @@ async fn process_single_batch(
     network: Network,
     accounts: &HashMap<String, PaymentReceiverAccount>,
     batch: &PaymentBatch,
+    max_input_count_per_tx: usize,
 ) -> Result<(), anyhow::Error> {
     let batch_id = &batch.id;
     println!("INFO: Starting processing for Batch ID: {}", batch_id);
@@ -101,74 +123,208 @@ async fn process_single_batch(
         .context("Failed to fetch payments for batch")?;
 
     if associated_payments.is_empty() {
-        return Err(anyhow!("Batch {} has no associated payments", batch_id));
+        println!(
+            "WARN: Batch {} has no active payments. Marking batch as CANCELLED.",
+            batch_id
+        );
+        PaymentBatch::update_to_failed(conn, batch_id, "No active payments found in batch").await?;
+        return Ok(());
     }
 
-    let total_amount: i64 = associated_payments.iter().map(|p| p.amount).sum();
     let account_name = &batch.account_name;
+    let sender_account = accounts
+        .get(&account_name.to_lowercase())
+        .ok_or_else(|| anyhow!("Account '{}' not found in local configuration", account_name))?;
 
-    println!(
-        "INFO: Batch {}: Locking funds via API. Account: '{}', Total Amount: {}",
-        batch_id, account_name, total_amount
-    );
+    // --- CYCLE 2 (Finalize) OR CYCLE 1 (Inputs Check) ---
+    if let Some(context_json) = &batch.intermediate_context_json {
+        // === CYCLE 2: FINALIZE ===
+        println!(
+            "INFO: Batch {}: Found intermediate context. Executing CYCLE 2 (Finalize).",
+            batch_id
+        );
 
-    let lock_funds_request = LockFundsRequest {
-        amount: total_amount,
-        idempotency_key: Some(Some(batch.pr_idempotency_key.clone())),
-        ..Default::default()
-    };
+        let context = IntermediateContext::from_json(context_json)?;
+        let inputs = context.utxos;
 
-    let locked_funds = match accounts_api::api_lock_funds(client_config, account_name, lock_funds_request).await {
-        Ok(response) => {
+        println!(
+            "INFO: Batch {}: Using {} intermediate inputs for final transaction.",
+            batch_id,
+            inputs.len()
+        );
+
+        let final_step = create_transaction_step(network, sender_account, inputs, &associated_payments, 0).await?;
+
+        let payload = BatchPayload {
+            steps: vec![final_step],
+        };
+        let payload_json = payload.to_json()?;
+
+        PaymentBatch::update_to_awaiting_signature(conn, batch_id, &payload_json)
+            .await
+            .context("Failed to update batch to AwaitingSignature (Cycle 2)")?;
+
+        println!(
+            "INFO: Batch {}: Cycle 2 preparation complete. Ready for signature.",
+            batch_id
+        );
+    } else {
+        // === CYCLE 1: FETCH & ANALYZE ===
+        println!(
+            "INFO: Batch {}: No context found. Fetching fresh UTXOs from API.",
+            batch_id
+        );
+
+        let payment_total: i64 = associated_payments.iter().map(|p| p.amount).sum();
+        let amount_to_lock = payment_total + FEE_BUFFER_AMOUNT;
+        let account_balance = accounts_api::api_get_balance(client_config, account_name).await?;
+        let balance = account_balance.total_credits.flatten().unwrap_or_default()
+            - account_balance.total_debits.flatten().unwrap_or_default();
+
+        if balance < amount_to_lock {
             println!(
-                "INFO: Batch {}: Funds locked successfully. Received {} inputs (UTXOs).",
-                batch_id,
-                response.utxos.len()
+                "WARN: Batch {}: Not enough funds in wallet {}. Requested (w/ buffer): {}, Actual: {}.",
+                batch_id, account_name, amount_to_lock, balance
             );
-            response
-        },
-        Err(ApiError::ResponseError(response_content)) => {
-            return Err(anyhow!(
-                "PR API returned unexpected status: {} - {}",
-                response_content.status,
-                response_content.content
-            ));
-        },
-        Err(e) => return Err(anyhow!("Network error calling PR API: {:?}", e)),
-    };
+            return Ok(());
+        }
 
-    println!("INFO: Batch {}: Preparing local offline signer...", batch_id);
+        let lock_request = LockFundsRequest {
+            amount: amount_to_lock,
+            idempotency_key: Some(Some(batch.pr_idempotency_key.clone())),
+            ..Default::default()
+        };
 
-    let first_recipient = &associated_payments[0];
-    let account = accounts
-        .get(&first_recipient.account_name.to_lowercase())
-        .ok_or_else(|| {
-            anyhow!(
-                "Account '{}' not found in local configuration",
-                first_recipient.account_name
-            )
-        })?;
+        let locked_funds = match accounts_api::api_lock_funds(client_config, account_name, lock_request).await {
+            Ok(res) => res,
+            Err(ApiError::ResponseError(c)) => return Err(anyhow!("PR API Error: {} - {}", c.status, c.content)),
+            Err(e) => return Err(anyhow!("Network error calling PR API: {:?}", e)),
+        };
 
-    let view_wallet = ViewWallet::new(account.public_spend_key.clone(), account.view_key.clone(), None);
+        let mut inputs: Vec<WalletOutput> = Vec::new();
+        for utxo_val in locked_funds.utxos {
+            let utxo: WalletOutput =
+                serde_json::from_value(utxo_val).map_err(|e| anyhow!("Failed to deserialize UTXO: {}", e))?;
+            inputs.push(utxo);
+        }
+
+        println!("INFO: Batch {}: API returned {} UTXOs.", batch_id, inputs.len());
+
+        if inputs.len() > max_input_count_per_tx {
+            // === SPLIT LOGIC ===
+            println!(
+                "INFO: Batch {}: Input count ({}) exceeds limit ({}). Initiating SPLIT (CoinJoin).",
+                batch_id,
+                inputs.len(),
+                max_input_count_per_tx
+            );
+
+            let chunks = inputs.chunks(max_input_count_per_tx);
+            let mut steps = Vec::new();
+
+            for (i, chunk) in chunks.enumerate() {
+                let tx_step = create_self_spend_step(network, sender_account, chunk.to_vec(), i).await?;
+                steps.push(tx_step);
+            }
+
+            let payload = BatchPayload { steps };
+            let payload_json = payload.to_json()?;
+
+            PaymentBatch::update_to_awaiting_signature(conn, batch_id, &payload_json)
+                .await
+                .context("Failed to update batch to AwaitingSignature (Split Cycle)")?;
+
+            println!(
+                "INFO: Batch {}: Split Cycle preparation complete. {} steps created.",
+                batch_id,
+                payload.steps.len()
+            );
+        } else {
+            // === NORMAL LOGIC ===
+            println!(
+                "INFO: Batch {}: Input count within limits. creating standard transaction.",
+                batch_id
+            );
+
+            let step = create_transaction_step(network, sender_account, inputs, &associated_payments, 0).await?;
+
+            let payload = BatchPayload { steps: vec![step] };
+            let payload_json = payload.to_json()?;
+
+            PaymentBatch::update_to_awaiting_signature(conn, batch_id, &payload_json)
+                .await
+                .context("Failed to update batch to AwaitingSignature (Normal)")?;
+
+            println!("INFO: Batch {}: Normal preparation complete.", batch_id);
+        }
+    }
+
+    Ok(())
+}
+
+async fn prepare_signing_request(
+    network: Network,
+    tx_id: TxId,
+    sender_account: &PaymentReceiverAccount,
+    inputs: &[WalletOutput],
+    recipients: &[PaymentRecipient],
+) -> Result<String, anyhow::Error> {
+    let view_wallet = ViewWallet::new(
+        sender_account.public_spend_key.clone(),
+        sender_account.view_key.clone(),
+        None,
+    );
     let key_manager = KeyManager::new(WalletType::ViewWallet(view_wallet)).context("Failed to create KeyManager")?;
 
     let consensus_constants = ConsensusConstantsBuilder::new(network).build();
-    let mut tx_builder = TransactionBuilder::new(consensus_constants, key_manager.clone(), network)
+    let mut tx_builder = TransactionBuilder::new(consensus_constants, key_manager, network)
         .context("Failed to create TransactionBuilder")?;
 
-    tx_builder.with_fee_per_gram(MicroMinotari(5));
+    tx_builder.with_fee_per_gram(MicroMinotari(FEE_PER_GRAM));
 
-    for utxo_value in &locked_funds.utxos {
-        let utxo: WalletOutput =
-            serde_json::from_value(utxo_value.clone()).map_err(|e| anyhow!("Failed to deserialize utxo: {}", e))?;
-        tx_builder
-            .with_input(utxo)
-            .context("Failed to add input to transaction")?;
+    for input in inputs {
+        tx_builder.with_input(input.clone()).context("Failed to add input")?;
     }
 
-    let output_features = OutputFeatures::default();
+    let prepare_result = prepare_one_sided_transaction_for_signing(
+        tx_id,
+        tx_builder,
+        recipients,
+        MemoField::new_empty(),
+        sender_account.address.clone(),
+    )
+    .context("Failed to prepare one-sided transaction")?;
+
+    let tx_json = serde_json::to_string(&prepare_result)?;
+    Ok(tx_json)
+}
+
+fn get_single_output_metadata_size(fee_calc: &Fee) -> Result<usize, anyhow::Error> {
+    let output_features_size = OutputFeatures::default()
+        .get_serialized_size()
+        .map_err(|e| anyhow!("Serialization error: {}", e))?;
+    let tari_script_size = TariScript::default()
+        .get_serialized_size()
+        .map_err(|e| anyhow!("Serialization error: {}", e))?;
+    let covenant_size = Covenant::default()
+        .get_serialized_size()
+        .map_err(|e| anyhow!("Serialization error: {}", e))?;
+
+    Ok(fee_calc
+        .weighting()
+        .round_up_features_and_scripts_size(output_features_size + tari_script_size + covenant_size))
+}
+
+async fn create_transaction_step(
+    network: Network,
+    sender_account: &PaymentReceiverAccount,
+    inputs: Vec<WalletOutput>,
+    payments: &[Payment],
+    step_index: usize,
+) -> Result<TransactionStep, anyhow::Error> {
     let tx_id = TxId::new_random();
-    let recipients: Vec<PaymentRecipient> = associated_payments
+    let output_features = OutputFeatures::default();
+    let recipients: Vec<PaymentRecipient> = payments
         .iter()
         .map(|p| -> Result<PaymentRecipient, anyhow::Error> {
             let payment_id = match &p.payment_id {
@@ -190,24 +346,63 @@ async fn process_single_batch(
             })
         })
         .collect::<Result<Vec<PaymentRecipient>, anyhow::Error>>()?;
+    let tx_json = prepare_signing_request(network, tx_id, sender_account, &inputs, &recipients).await?;
 
-    println!("INFO: Batch {}: Building transaction outputs...", batch_id);
+    Ok(TransactionStep {
+        step_index,
+        is_consolidation: false,
+        payload: StepPayload::Unsigned(tx_json),
+        tx_id,
+    })
+}
 
-    let payment_id = MemoField::new_empty();
-    let result =
-        prepare_one_sided_transaction_for_signing(tx_id, tx_builder, &recipients, payment_id, account.address.clone())
-            .context("Failed to prepare one-sided transaction")?;
+async fn create_self_spend_step(
+    network: Network,
+    sender_account: &PaymentReceiverAccount,
+    inputs: Vec<WalletOutput>,
+    step_index: usize,
+) -> Result<TransactionStep, anyhow::Error> {
+    let tx_id = TxId::new_random();
 
-    let response_text = serde_json::to_string(&result).context("Failed to serialize transaction result")?;
+    let total_input_value: MicroMinotari = inputs.iter().map(|p| p.value()).sum();
+    let fee_calc = Fee::new(TransactionWeight::latest());
+    let output_metadata_size = get_single_output_metadata_size(&fee_calc)?;
+    let calculated_fee = fee_calc.calculate(MicroMinotari(FEE_PER_GRAM), 1, inputs.len(), 1, output_metadata_size);
 
-    PaymentBatch::update_to_awaiting_signature(conn, batch_id, &response_text)
-        .await
-        .context("Failed to update batch status to AwaitingSignature")?;
+    if calculated_fee >= total_input_value {
+        return Err(anyhow!(
+            "Input value {:?} is too small to cover fees {:?}",
+            total_input_value,
+            calculated_fee
+        ));
+    }
+
+    let amount_to_self = total_input_value - calculated_fee;
 
     println!(
-        "INFO: Batch {}: Unsigned transaction created. Status updated to 'AwaitingSignature'.",
-        batch_id
+        "DEBUG: Self-Spend Step {}: Inputs Sum: {:?}, Inputs Count: {}, Fee: {:?}, Net Output: {:?}",
+        step_index,
+        total_input_value,
+        inputs.len(),
+        calculated_fee,
+        amount_to_self
     );
 
-    Ok(())
+    let output_features = OutputFeatures::default();
+    let recipient = PaymentRecipient {
+        amount: amount_to_self,
+        output_features,
+        address: sender_account.address.clone(),
+        payment_id: MemoField::new_empty(),
+    };
+
+    let recipients = vec![recipient];
+    let tx_json = prepare_signing_request(network, tx_id, sender_account, &inputs, &recipients).await?;
+
+    Ok(TransactionStep {
+        step_index,
+        is_consolidation: true,
+        payload: StepPayload::Unsigned(tx_json),
+        tx_id,
+    })
 }


### PR DESCRIPTION
Description
---

This PR introduces two main improvements:

**1. Automated UTXO Splitting (Chained Transactions)**
*   If a transaction requires more UTXOs than allowed by `MAX_INPUT_COUNT_PER_TX`, the system will now split the transaction.
*   It creates a self-transfer (consolidation) transaction first, followed by a transaction to the intended recipient using the unconfirmed outputs (0-conf).

**2. Payment Cancellation API**
*   Adds a new endpoint to allow users to cancel a pending payment.

**New Environment Variables:**
*   `MAX_INPUT_COUNT_PER_TX`: (Integer) The maximum number of inputs allowed in a single transaction before splitting occurs. *Default: 400*
*   `CONFIRMATION_CHECKER_REQUIRED_CONFIRMATIONS`: (Integer) The number of confirmations required. *Default: 10*

Motivation and Context
---

Previously, if a user submitted a transaction requiring a massive number of UTXOs (making the TX size/weight too large for standard propagation or block limits), the transaction would simply fail.

This PR solves this by detecting heavy transactions and breaking them down:
**Step 1:** Create a transaction to self to consolidate inputs.
**Step 2:** immediately spend the output of Step 1 to pay the recipient (chaining the transactions).

Additionally, we needed a way to manually stop payments, hence the new Cancel API.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
